### PR TITLE
Feat snapshot getters

### DIFF
--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -4,6 +4,10 @@ class TimeConstants {
   static const int secondsInMinute = 60;
   static const int millisecondsInSecond = 1000;
 
+  static const int millisecondsInYear = millisecondsInDay * 365;
+
+  static const int millisecondsInLeapYear = millisecondsInDay * 366;
+
   static const int millisecondsInDay =
       hoursInDay * minutesInHour * secondsInMinute * millisecondsInSecond;
 

--- a/lib/src/snapshot.dart
+++ b/lib/src/snapshot.dart
@@ -193,6 +193,16 @@ class Snapshot {
   bool get isLeapYear => _isLeapYear(year);
   int get daysInMonth => _daysInMonth(month, year);
 
+  Snapshot get endOfDay => Snapshot(
+        year: year,
+        month: month,
+        day: day,
+        hour: 23,
+        minute: 59,
+        second: 59,
+        millisecond: 999,
+      );
+
   bool _isLeapYear(int year) {
     return year % 4 == 0 && (!(year % 100 == 0) || year % 400 == 0);
   }

--- a/lib/src/snapshot.dart
+++ b/lib/src/snapshot.dart
@@ -213,6 +213,16 @@ class Snapshot {
         millisecond: 999,
       );
 
+  Snapshot get endOfMinute => Snapshot(
+        year: year,
+        month: month,
+        day: day,
+        hour: hour,
+        minute: minute,
+        second: 59,
+        millisecond: 999,
+      );
+
   bool _isLeapYear(int year) {
     return year % 4 == 0 && (!(year % 100 == 0) || year % 400 == 0);
   }

--- a/lib/src/snapshot.dart
+++ b/lib/src/snapshot.dart
@@ -223,6 +223,16 @@ class Snapshot {
         millisecond: 999,
       );
 
+  Snapshot get endOfSecond => Snapshot(
+        year: year,
+        month: month,
+        day: day,
+        hour: hour,
+        minute: minute,
+        second: second,
+        millisecond: 999,
+      );
+
   bool _isLeapYear(int year) {
     return year % 4 == 0 && (!(year % 100 == 0) || year % 400 == 0);
   }

--- a/lib/src/snapshot.dart
+++ b/lib/src/snapshot.dart
@@ -203,6 +203,16 @@ class Snapshot {
         millisecond: 999,
       );
 
+  Snapshot get endOfHour => Snapshot(
+        year: year,
+        month: month,
+        day: day,
+        hour: hour,
+        minute: 59,
+        second: 59,
+        millisecond: 999,
+      );
+
   bool _isLeapYear(int year) {
     return year % 4 == 0 && (!(year % 100 == 0) || year % 400 == 0);
   }

--- a/lib/src/snapshot.dart
+++ b/lib/src/snapshot.dart
@@ -127,9 +127,11 @@ class Snapshot {
     );
   }
 
-  factory Snapshot.fromEpochTime(int millisecondsSinceEpoch) {
-    final datetime =
-        DateTime.fromMillisecondsSinceEpoch(millisecondsSinceEpoch);
+  factory Snapshot.fromEpochTime(int millisecondsSinceEpoch, bool isUtc) {
+    final datetime = DateTime.fromMillisecondsSinceEpoch(
+      millisecondsSinceEpoch,
+      isUtc: isUtc,
+    );
 
     return Snapshot(
       millisecond: datetime.millisecond,

--- a/lib/src/snapshot.dart
+++ b/lib/src/snapshot.dart
@@ -193,6 +193,16 @@ class Snapshot {
   bool get isLeapYear => _isLeapYear(year);
   int get daysInMonth => _daysInMonth(month, year);
 
+  Snapshot get endOfMonth => Snapshot(
+        year: year,
+        month: month,
+        day: _daysInMonth(month, year),
+        hour: 23,
+        minute: 59,
+        second: 59,
+        millisecond: 999,
+      );
+
   Snapshot get endOfDay => Snapshot(
         year: year,
         month: month,

--- a/lib/src/snapshot.dart
+++ b/lib/src/snapshot.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
 import 'package:meta/meta.dart';
 import 'package:timeout/src/constants.dart';
 
@@ -95,7 +94,7 @@ class Snapshot {
         minute,
         second,
         millisecond,
-      ).toUtc().millisecondsSinceEpoch;
+      ).millisecondsSinceEpoch;
     } catch (err) {
       rethrow;
     }

--- a/lib/src/snapshot.dart
+++ b/lib/src/snapshot.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:meta/meta.dart';
+import 'package:timeout/src/constants.dart';
 
 import 'snapshot_exceptions.dart';
 
@@ -115,6 +116,21 @@ class Snapshot {
   }
 
   factory Snapshot.fromDateTime(DateTime datetime) {
+    return Snapshot(
+      millisecond: datetime.millisecond,
+      second: datetime.second,
+      minute: datetime.minute,
+      hour: datetime.hour,
+      day: datetime.day,
+      month: datetime.month,
+      year: datetime.year,
+    );
+  }
+
+  factory Snapshot.fromEpochTime(int millisecondsSinceEpoch) {
+    final datetime =
+        DateTime.fromMillisecondsSinceEpoch(millisecondsSinceEpoch);
+
     return Snapshot(
       millisecond: datetime.millisecond,
       second: datetime.second,

--- a/lib/src/snapshot.dart
+++ b/lib/src/snapshot.dart
@@ -193,6 +193,16 @@ class Snapshot {
   bool get isLeapYear => _isLeapYear(year);
   int get daysInMonth => _daysInMonth(month, year);
 
+  Snapshot get endOfYear => Snapshot(
+        year: year,
+        month: 12,
+        day: 31,
+        hour: 23,
+        minute: 59,
+        second: 59,
+        millisecond: 999,
+      );
+
   Snapshot get endOfMonth => Snapshot(
         year: year,
         month: month,

--- a/test/snapshot_test.dart
+++ b/test/snapshot_test.dart
@@ -704,6 +704,34 @@ void main() {
     });
   });
 
+  group('Snapshot fromEpochTime() factory', () {
+    test(
+        'should create a Snapshot and convert back to milliseconds since epoch',
+        () {
+      final snapshot = Snapshot(
+        year: 2024,
+        month: 2,
+        day: 12,
+        hour: 12,
+        minute: 37,
+        second: 31,
+        millisecond: 400,
+      );
+
+      final epochTime = snapshot.epochTime;
+
+      final fromEpochTime = Snapshot.fromEpochTime(epochTime, true);
+
+      expect(fromEpochTime.year, snapshot.year);
+      expect(fromEpochTime.month, snapshot.month);
+      expect(fromEpochTime.day, snapshot.day);
+      expect(fromEpochTime.hour, snapshot.hour);
+      expect(fromEpochTime.minute, snapshot.minute);
+      expect(fromEpochTime.second, snapshot.second);
+      expect(fromEpochTime.millisecond, snapshot.millisecond);
+    });
+  });
+
   group("Snapshot endOfYear getter", () {
     test('should return the end of the year', () {
       // Arrange

--- a/test/snapshot_test.dart
+++ b/test/snapshot_test.dart
@@ -702,6 +702,28 @@ void main() {
       expect(endOfDaySnapshot.second, 59);
       expect(endOfDaySnapshot.millisecond, 999);
     });
+
+    test('should return a Snapshot representing the end of the hour', () {
+      final snapshot = Snapshot(
+        year: 2023,
+        month: 7,
+        day: 24,
+        hour: 15,
+        minute: 30,
+        second: 45,
+        millisecond: 500,
+      );
+
+      final endOfHourSnapshot = snapshot.endOfHour;
+
+      expect(endOfHourSnapshot.year, 2023);
+      expect(endOfHourSnapshot.month, 7);
+      expect(endOfHourSnapshot.day, 24);
+      expect(endOfHourSnapshot.hour, 15);
+      expect(endOfHourSnapshot.minute, 59);
+      expect(endOfHourSnapshot.second, 59);
+      expect(endOfHourSnapshot.millisecond, 999);
+    });
   });
 
   group("Snapshot hashCode method", () {

--- a/test/snapshot_test.dart
+++ b/test/snapshot_test.dart
@@ -724,6 +724,28 @@ void main() {
       expect(endOfHourSnapshot.second, 59);
       expect(endOfHourSnapshot.millisecond, 999);
     });
+
+    test('should return a Snapshot representing the end of the minute', () {
+      final snapshot = Snapshot(
+        year: 2023,
+        month: 7,
+        day: 24,
+        hour: 15,
+        minute: 30,
+        second: 45,
+        millisecond: 500,
+      );
+
+      final endOfMinuteSnapshot = snapshot.endOfMinute;
+
+      expect(endOfMinuteSnapshot.year, 2023);
+      expect(endOfMinuteSnapshot.month, 7);
+      expect(endOfMinuteSnapshot.day, 24);
+      expect(endOfMinuteSnapshot.hour, 15);
+      expect(endOfMinuteSnapshot.minute, 30);
+      expect(endOfMinuteSnapshot.second, 59);
+      expect(endOfMinuteSnapshot.millisecond, 999);
+    });
   });
 
   group("Snapshot hashCode method", () {

--- a/test/snapshot_test.dart
+++ b/test/snapshot_test.dart
@@ -704,6 +704,159 @@ void main() {
     });
   });
 
+  group('Snapshot endOfMonth getter', () {
+    test('should return the end of February for a non-leap year', () {
+      // Arrange
+      final snapshot = Snapshot(
+        year: 2023,
+        month: 2,
+        day: 1,
+        hour: 12,
+        minute: 30,
+        second: 45,
+        millisecond: 500,
+      );
+
+      // Act
+      final endOfMonthSnapshot = snapshot.endOfMonth;
+
+      // Assert
+      expect(endOfMonthSnapshot.year, 2023);
+      expect(endOfMonthSnapshot.month, 2);
+      expect(endOfMonthSnapshot.day, 28); // February 2023 has 28 days.
+      expect(endOfMonthSnapshot.hour, 23);
+      expect(endOfMonthSnapshot.minute, 59);
+      expect(endOfMonthSnapshot.second, 59);
+      expect(endOfMonthSnapshot.millisecond, 999);
+    });
+
+    test('should return the end of February for a leap year', () {
+      // Arrange
+      final snapshot = Snapshot(
+        year: 2024,
+        month: 2,
+        day: 1,
+        hour: 12,
+        minute: 30,
+        second: 45,
+        millisecond: 500,
+      );
+
+      // Act
+      final endOfMonthSnapshot = snapshot.endOfMonth;
+
+      // Assert
+      expect(endOfMonthSnapshot.year, 2024);
+      expect(endOfMonthSnapshot.month, 2);
+      expect(endOfMonthSnapshot.day,
+          29); // February 2024 is a leap year with 29 days.
+      expect(endOfMonthSnapshot.hour, 23);
+      expect(endOfMonthSnapshot.minute, 59);
+      expect(endOfMonthSnapshot.second, 59);
+      expect(endOfMonthSnapshot.millisecond, 999);
+    });
+
+    test('should return the end of April', () {
+      // Arrange
+      final snapshot = Snapshot(
+        year: 2023,
+        month: 4,
+        day: 1,
+        hour: 12,
+        minute: 30,
+        second: 45,
+        millisecond: 500,
+      );
+
+      // Act
+      final endOfMonthSnapshot = snapshot.endOfMonth;
+
+      // Assert
+      expect(endOfMonthSnapshot.year, 2023);
+      expect(endOfMonthSnapshot.month, 4);
+      expect(endOfMonthSnapshot.day, 30); // April 2023 has 30 days.
+      expect(endOfMonthSnapshot.hour, 23);
+      expect(endOfMonthSnapshot.minute, 59);
+      expect(endOfMonthSnapshot.second, 59);
+      expect(endOfMonthSnapshot.millisecond, 999);
+    });
+
+    test('should return the end of June', () {
+      // Arrange
+      final snapshot = Snapshot(
+        year: 2023,
+        month: 6,
+        day: 1,
+        hour: 12,
+        minute: 30,
+        second: 45,
+        millisecond: 500,
+      );
+
+      // Act
+      final endOfMonthSnapshot = snapshot.endOfMonth;
+
+      // Assert
+      expect(endOfMonthSnapshot.year, 2023);
+      expect(endOfMonthSnapshot.month, 6);
+      expect(endOfMonthSnapshot.day, 30); // June 2023 has 30 days.
+      expect(endOfMonthSnapshot.hour, 23);
+      expect(endOfMonthSnapshot.minute, 59);
+      expect(endOfMonthSnapshot.second, 59);
+      expect(endOfMonthSnapshot.millisecond, 999);
+    });
+
+    test('should return the end of September', () {
+      // Arrange
+      final snapshot = Snapshot(
+        year: 2023,
+        month: 9,
+        day: 1,
+        hour: 12,
+        minute: 30,
+        second: 45,
+        millisecond: 500,
+      );
+
+      // Act
+      final endOfMonthSnapshot = snapshot.endOfMonth;
+
+      // Assert
+      expect(endOfMonthSnapshot.year, 2023);
+      expect(endOfMonthSnapshot.month, 9);
+      expect(endOfMonthSnapshot.day, 30); // September 2023 has 30 days.
+      expect(endOfMonthSnapshot.hour, 23);
+      expect(endOfMonthSnapshot.minute, 59);
+      expect(endOfMonthSnapshot.second, 59);
+      expect(endOfMonthSnapshot.millisecond, 999);
+    });
+
+    test('should return the end of November', () {
+      // Arrange
+      final snapshot = Snapshot(
+        year: 2023,
+        month: 11,
+        day: 1,
+        hour: 12,
+        minute: 30,
+        second: 45,
+        millisecond: 500,
+      );
+
+      // Act
+      final endOfMonthSnapshot = snapshot.endOfMonth;
+
+      // Assert
+      expect(endOfMonthSnapshot.year, 2023);
+      expect(endOfMonthSnapshot.month, 11);
+      expect(endOfMonthSnapshot.day, 30); // November 2023 has 30 days.
+      expect(endOfMonthSnapshot.hour, 23);
+      expect(endOfMonthSnapshot.minute, 59);
+      expect(endOfMonthSnapshot.second, 59);
+      expect(endOfMonthSnapshot.millisecond, 999);
+    });
+  });
+
   group("Snapshot endOfHour getter", () {
     test('should return a Snapshot representing the end of the hour', () {
       final snapshot = Snapshot(

--- a/test/snapshot_test.dart
+++ b/test/snapshot_test.dart
@@ -702,7 +702,9 @@ void main() {
       expect(endOfDaySnapshot.second, 59);
       expect(endOfDaySnapshot.millisecond, 999);
     });
+  });
 
+  group("Snapshot endOfHour getter", () {
     test('should return a Snapshot representing the end of the hour', () {
       final snapshot = Snapshot(
         year: 2023,
@@ -724,7 +726,9 @@ void main() {
       expect(endOfHourSnapshot.second, 59);
       expect(endOfHourSnapshot.millisecond, 999);
     });
+  });
 
+  group("Snapshot endOfMinute getter", () {
     test('should return a Snapshot representing the end of the minute', () {
       final snapshot = Snapshot(
         year: 2023,
@@ -746,7 +750,9 @@ void main() {
       expect(endOfMinuteSnapshot.second, 59);
       expect(endOfMinuteSnapshot.millisecond, 999);
     });
+  });
 
+  group("Snapshot endOfSecond getter", () {
     test('should return a Snapshot representing the end of the second', () {
       final snapshot = Snapshot(
         year: 2023,

--- a/test/snapshot_test.dart
+++ b/test/snapshot_test.dart
@@ -746,6 +746,28 @@ void main() {
       expect(endOfMinuteSnapshot.second, 59);
       expect(endOfMinuteSnapshot.millisecond, 999);
     });
+
+    test('should return a Snapshot representing the end of the second', () {
+      final snapshot = Snapshot(
+        year: 2023,
+        month: 7,
+        day: 24,
+        hour: 15,
+        minute: 30,
+        second: 45,
+        millisecond: 500,
+      );
+
+      final endOfSecondSnapshot = snapshot.endOfSecond;
+
+      expect(endOfSecondSnapshot.year, 2023);
+      expect(endOfSecondSnapshot.month, 7);
+      expect(endOfSecondSnapshot.day, 24);
+      expect(endOfSecondSnapshot.hour, 15);
+      expect(endOfSecondSnapshot.minute, 30);
+      expect(endOfSecondSnapshot.second, 45);
+      expect(endOfSecondSnapshot.millisecond, 999);
+    });
   });
 
   group("Snapshot hashCode method", () {

--- a/test/snapshot_test.dart
+++ b/test/snapshot_test.dart
@@ -680,6 +680,30 @@ void main() {
     });
   });
 
+  group("Snapshot endOfDay getter", () {
+    test('should return a Snapshot representing the end of the day', () {
+      final snapshot = Snapshot(
+        year: 2023,
+        month: 7,
+        day: 24,
+        hour: 12,
+        minute: 30,
+        second: 45,
+        millisecond: 500,
+      );
+
+      final endOfDaySnapshot = snapshot.endOfDay;
+
+      expect(endOfDaySnapshot.year, 2023);
+      expect(endOfDaySnapshot.month, 7);
+      expect(endOfDaySnapshot.day, 24);
+      expect(endOfDaySnapshot.hour, 23);
+      expect(endOfDaySnapshot.minute, 59);
+      expect(endOfDaySnapshot.second, 59);
+      expect(endOfDaySnapshot.millisecond, 999);
+    });
+  });
+
   group("Snapshot hashCode method", () {
     test('should return the same hash code for equal Snapshots', () {
       final snapshot1 = Snapshot(

--- a/test/snapshot_test.dart
+++ b/test/snapshot_test.dart
@@ -706,29 +706,29 @@ void main() {
 
   group('Snapshot fromEpochTime() factory', () {
     test(
-        'should create a Snapshot and convert back to milliseconds since epoch',
+        'should create a Snapshot and convert back to milliseconds since epoch without using UTC',
         () {
-      final snapshot = Snapshot(
-        year: 2024,
-        month: 2,
-        day: 12,
-        hour: 12,
-        minute: 37,
-        second: 31,
-        millisecond: 400,
+      final firstSnapshot = Snapshot(
+        year: 2021,
+        month: 7,
+        day: 29,
+        hour: 22,
+        minute: 11,
+        second: 25,
+        millisecond: 0,
       );
 
-      final epochTime = snapshot.epochTime;
+      final epochTime = firstSnapshot.epochTime;
 
-      final fromEpochTime = Snapshot.fromEpochTime(epochTime, true);
+      final fromEpochTime = Snapshot.fromEpochTime(epochTime, false);
 
-      expect(fromEpochTime.year, snapshot.year);
-      expect(fromEpochTime.month, snapshot.month);
-      expect(fromEpochTime.day, snapshot.day);
-      expect(fromEpochTime.hour, snapshot.hour);
-      expect(fromEpochTime.minute, snapshot.minute);
-      expect(fromEpochTime.second, snapshot.second);
-      expect(fromEpochTime.millisecond, snapshot.millisecond);
+      expect(fromEpochTime.year, firstSnapshot.year);
+      expect(fromEpochTime.month, firstSnapshot.month);
+      expect(fromEpochTime.day, firstSnapshot.day);
+      expect(fromEpochTime.hour, firstSnapshot.hour);
+      expect(fromEpochTime.minute, firstSnapshot.minute);
+      expect(fromEpochTime.second, firstSnapshot.second);
+      expect(fromEpochTime.millisecond, firstSnapshot.millisecond);
     });
   });
 

--- a/test/snapshot_test.dart
+++ b/test/snapshot_test.dart
@@ -704,6 +704,33 @@ void main() {
     });
   });
 
+  group("Snapshot endOfYear getter", () {
+    test('should return the end of the year', () {
+      // Arrange
+      final snapshot = Snapshot(
+        year: 2023,
+        month: 6,
+        day: 10,
+        hour: 12,
+        minute: 30,
+        second: 45,
+        millisecond: 500,
+      );
+
+      // Act
+      final endOfYearSnapshot = snapshot.endOfYear;
+
+      // Assert
+      expect(endOfYearSnapshot.year, 2023);
+      expect(endOfYearSnapshot.month, 12);
+      expect(endOfYearSnapshot.day, 31);
+      expect(endOfYearSnapshot.hour, 23);
+      expect(endOfYearSnapshot.minute, 59);
+      expect(endOfYearSnapshot.second, 59);
+      expect(endOfYearSnapshot.millisecond, 999);
+    });
+  });
+
   group('Snapshot endOfMonth getter', () {
     test('should return the end of February for a non-leap year', () {
       // Arrange


### PR DESCRIPTION
Add some Snapshot getters for endOfX, they are going to be useful for later functionality implementations, also add the `Snapshot.fromEpochTime()` that is not fully functional yet, it doesn't work with UTC as of now, only in the local timezone. 